### PR TITLE
Update all prices after every Spree::FxRate save

### DIFF
--- a/app/controllers/spree/admin/fx_rates_controller.rb
+++ b/app/controllers/spree/admin/fx_rates_controller.rb
@@ -1,8 +1,6 @@
 module Spree
   module Admin
     class FxRatesController < ResourceController
-      after_action :update_all_prices, only: [:update, :create]
-
       def fetch_all
         if Spree::FxRate.fetch_fixer
           flash[:notice] = 'Rates was successfuly fetched'
@@ -19,12 +17,6 @@ module Spree
           flash[:alert] = 'Something was wrong'
         end
         redirect_to :admin_fx_rates
-      end
-
-      private
-
-      def update_all_prices
-        @fx_rate.update_all_prices
       end
     end
   end

--- a/app/models/spree/fx_rate.rb
+++ b/app/models/spree/fx_rate.rb
@@ -7,6 +7,8 @@ module Spree
       greater_than_or_equal_to: 0
     }
 
+    after_save :update_all_prices
+
     def self.create_supported_currencies
       return unless table_exists?
       main_currency = Spree::Config.currency

--- a/lib/spree_fx_currency/version.rb
+++ b/lib/spree_fx_currency/version.rb
@@ -10,7 +10,7 @@ module SpreeFxCurrency
   module VERSION
     MAJOR = 3
     MINOR = 0
-    TINY  = 1
+    TINY  = 2
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')


### PR DESCRIPTION
Fixes #1 

Spec on `#update_all_prices` already present [spec/models/spree/fx_rate_spec.rb](https://github.com/itbeaver/spree_fx_currency/blob/3-0-stable/spec/models/spree/fx_rate_spec.rb#L18)
