### PR TITLE
Fix rubocop offences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,6 @@ Style/AsciiComments:
   Enabled: false
 Metrics/LineLength:
   Max: 100
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/**/*'

--- a/app/models/spree/fx_rate.rb
+++ b/app/models/spree/fx_rate.rb
@@ -11,21 +11,32 @@ module Spree
 
     after_save :update_all_prices
 
+    def self.spree_currency
+      Spree::Config.currency
+    end
+
+    def self.supported_currencies
+      Spree::Config.supported_currencies.split(', ')
+                   .reject { |c| spree_currency.to_s == c.upcase }
+    rescue NoMethodError => _e
+      []
+    end
+
+    def self.sync_currencies_from_config
+      found_currencies = supported_currencies.map do |c|
+        find_or_create_by(from_currency: spree_currency, to_currency: c.upcase).id
+      end
+      where.not(id: found_currencies).destroy_all
+    end
+
     def self.create_supported_currencies
       return unless table_exists?
-      main_currency = Spree::Config.currency
-      currencies = Spree::Config.supported_currencies.try(:split, ', ') || []
-      ids = currencies.reject { |c| main_currency.to_s == c.upcase }.map do |c|
-        find_or_create_by(
-          from_currency: main_currency, to_currency: c.upcase
-        ).id
-      end
-      where.not(id: ids).destroy_all if ids.present?
+      sync_currencies_from_config
       fetch_fixer if Rails.env.production?
     end
 
     def self.fetch_fixer
-      request = FixerClient.new(Spree::Config.currency, pluck(:to_currency))
+      request = FixerClient.new(spree_currency, pluck(:to_currency))
       request.fetch.each do |currency, value|
         find_by(to_currency: currency).try(:update_attributes, rate: value)
       end


### PR DESCRIPTION
Closes #12 

Availability of separated methods `Spree::FxRate.spree_currency`, `Spree::FxRate.supported_currencies` provides easier customization of the gem by decorating model (e.g. use without spree_multi_currency gem)
