### PR TITLE
Update product prices automaticly according to current rates after create/clone

### DIFF
--- a/app/models/spree/fx_rate.rb
+++ b/app/models/spree/fx_rate.rb
@@ -9,7 +9,7 @@ module Spree
       greater_than_or_equal_to: 0
     }
 
-    after_save :update_all_prices
+    after_save :update_products_prices
 
     def self.create_supported_currencies
       return unless table_exists?
@@ -41,15 +41,13 @@ module Spree
 
     # @todo: implement force option for only applying
     #        fx rate changes to blank prices
-    def update_all_prices
+    def update_products_prices
       Spree::Product.transaction do
-        Spree::Product.all.each { |p| proccess_variants(p) }
+        Spree::Product.all.each { |p| update_prices_for(p) }
       end
     end
 
-    private
-
-    def proccess_variants(product)
+    def update_prices_for(product)
       product.variants_including_master.each do |variant|
         from_price = variant.price_in(from_currency.upcase)
 

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,0 +1,7 @@
+Spree::Product.class_eval do
+  after_create :update_prices
+
+  def update_prices
+    Spree::FxRate.all.each { |r| r.update_prices_for(self) }
+  end
+end

--- a/lib/spree_fx_currency/version.rb
+++ b/lib/spree_fx_currency/version.rb
@@ -10,7 +10,7 @@ module SpreeFxCurrency
   module VERSION
     MAJOR = 3
     MINOR = 0
-    TINY  = 2
+    TINY  = 3
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/lib/tasks/update_prices.rake
+++ b/lib/tasks/update_prices.rake
@@ -2,7 +2,7 @@ namespace :spree_fx_currency do
   namespace :update do
     desc 'Updates all prices according to FX Rates'
     task prices: :environment do
-      Spree::FxRate.all.each(&:update_all_prices)
+      Spree::FxRate.all.each(&:update_products_prices)
       puts 'Done!'
     end
 

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -8,14 +8,16 @@ describe Spree::Product, type: :model do
 
       it 'prices created for new product' do
         variants_ids = product.variants_including_master.pluck(:id)
-        prices = Spree::Price.where(id: variants_ids).pluck(:currency, :amount)
+        prices = Spree::Price.where(
+          variant_id: variants_ids
+        ).order(:id).pluck(:currency, :amount)
 
         clone = product.duplicate
 
         clone_variants_ids = clone.variants_including_master.pluck(:id)
         clone_prices = Spree::Price.where(
-          id: clone_variants_ids
-        ).pluck(:currency, :amount)
+          variant_id: clone_variants_ids
+        ).order(:id).pluck(:currency, :amount)
 
         expect(clone_prices).to eq(prices)
       end
@@ -27,7 +29,7 @@ describe Spree::Product, type: :model do
 
       it 'prices created for new product' do
         variants_ids = product.variants_including_master.pluck(:id)
-        prices = Spree::Price.where(id: variants_ids)
+        prices = Spree::Price.where(variant_id: variants_ids).order(:id)
                              .map { |p| [p.currency, p.display_amount.to_s] }
 
         expect(prices).to eq(

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -1,0 +1,39 @@
+describe Spree::Product, type: :model do
+  context 'when fx rates is present' do
+    let!(:to_eur) { create(:fx_rate, to_currency: 'EUR', rate: 0.884791322) }
+
+    context 'clone product' do
+      let(:product) { create(:product, price: 10.00) }
+      let(:variant) { create(:variant, product: product) }
+
+      it 'prices created for new product' do
+        variants_ids = product.variants_including_master.pluck(:id)
+        prices = Spree::Price.where(id: variants_ids).pluck(:currency, :amount)
+
+        clone = product.duplicate
+
+        clone_variants_ids = clone.variants_including_master.pluck(:id)
+        clone_prices = Spree::Price.where(
+          id: clone_variants_ids
+        ).pluck(:currency, :amount)
+
+        expect(clone_prices).to eq(prices)
+      end
+    end
+
+    context 'when create new product' do
+      let(:product) { create(:product, price: 10.00) }
+      let(:variant) { create(:variant, product: product) }
+
+      it 'prices created for new product' do
+        variants_ids = product.variants_including_master.pluck(:id)
+        prices = Spree::Price.where(id: variants_ids)
+                             .map { |p| [p.currency, p.display_amount.to_s] }
+
+        expect(prices).to eq(
+          [['USD', '$10.00'], ['EUR', '€8.85']]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #11 
- Improve methods naming
- Spec on clone and create product
